### PR TITLE
A small fix of application:get_env/2 usage

### DIFF
--- a/src/annotations_pt.erl
+++ b/src/annotations_pt.erl
@@ -248,7 +248,7 @@ progress_message(Msg, Args) ->
 
 is_verbose() ->
     case application:get_env(rebar_global, verbose) of
-        false     -> check_env();
+        undefined -> check_env();
         {ok, "0"} -> check_env();
         {ok, "1"} -> rebar_verbose
     end.


### PR DESCRIPTION
application:get_env/2 does not return 'false' in case no env variable has been found, it returns 'undefined' instead. Bug happens when used outside of rebar

Best,
Gleb
